### PR TITLE
Automatically collapse Unity generated diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,3 +45,10 @@
 *.tga filter=lfs diff=lfs merge=lfs -text
 *.tif filter=lfs diff=lfs merge=lfs -text
 *.tiff filter=lfs diff=lfs merge=lfs -text
+
+# Collapse Unity-generated files on GitHub
+*.asset linguist-generated
+*.mat linguist-generated
+*.meta linguist-generated
+*.prefab linguist-generated
+*.unity linguist-generated


### PR DESCRIPTION
When reviewing PRs, this commit allows us to hide diffs of files generated by Unity. This will make it easier to see changes in a commit.